### PR TITLE
Refactor property type handling for 'ano' field

### DIFF
--- a/src/ClientCatastro.php
+++ b/src/ClientCatastro.php
@@ -82,7 +82,7 @@ class ClientCatastro
         $inmueble->usoPrincipal = $data['bico']['bi']['debi']['luso'];
         $inmueble->superficie = $data['bico']['bi']['debi']['sfc'];
         $inmueble->participacionDeInmueble = (float)str_replace(',', '.', $data['bico']['bi']['debi']['cpt']);
-        $inmueble->ano = $data['bico']['bi']['debi']['ant'];
+        $inmueble->ano = $data['bico']['bi']['debi']['ant'] ?? null;
         if (isset($data['bico']['lcons'])) {
             foreach ($data['bico']['lcons'] as $construction) {
                 $inmueble->construcciones[] = $this->parseConstruction($construction);

--- a/src/models/Inmueble.php
+++ b/src/models/Inmueble.php
@@ -12,7 +12,7 @@ class Inmueble
     // Surface of the property in square meters
     public string $superficie = '';
     // Year of construction
-    public string $ano = '';
+    public ?string $ano = '';
     // Percent of the main property
     public ?float $participacionDeInmueble = null;
     /** @var \Construction[] */


### PR DESCRIPTION
Update the 'ano' field in the Inmueble model to accept null values, improving data flexibility. Adjust the data parsing in ClientCatastro to set the 'ano' field to null if no data is present.