### PR TITLE
Fix data type for 'planta' and format class declaration

### DIFF
--- a/src/models/Construction.php
+++ b/src/models/Construction.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace floor12\catastro\models;
-class Construction
+class   Construction
 {
     // Main usage/type of the property
     public string $usePrincipal = '';
@@ -10,7 +10,7 @@ class Construction
     // Stair number
     public ?int $escalera = null;
     // Floor number
-    public ?int $planta = null;
+    public ?string $planta = null;
     // Door number
     public ?int $puerta = null;
     // Surface of the property in square meters


### PR DESCRIPTION
Changed the data type of the 'planta' property from int to string to accommodate alphanumeric floor identifiers. Also reformatted the class declaration for consistent code styling.